### PR TITLE
Released version 0.2.0 of LAMPy visualization tool

### DIFF
--- a/lampy/README.md
+++ b/lampy/README.md
@@ -20,3 +20,11 @@ Create a Python 3.7 environment, if it's not the default one', by typing
 To install LAMPy, you can build it from the source code, or you can download the latest stable version from Pypi, installing it via pip
 
 `pip install lampy`
+
+## Build LAMPy from source
+
+To build LAMPy from source, you must run the following commands
+
+- `python setup.py build_clib` that compiles the C libraries needed to read the data files using a system C compiler,
+- `python setup.py develop` that builds the cython and python sources and installs the package in the `$PYTHONENV`.
+

--- a/lampy/lampy/Simulation.py
+++ b/lampy/lampy/Simulation.py
@@ -8,7 +8,7 @@ import os
 try:
     import seaborn as sns
     imported_seaborn = True
-except:
+except ImportError:
     print("Cannot find seaborn module. Plots will be drawn according to the\
             standard matplotlib style.")
     imported_seaborn = False
@@ -122,6 +122,11 @@ class Simulation(object):
                 if value in elem:
                     output_list += [key]
                     break
+
+        if 'Ey' in output_list and 'Bz' in output_list:
+            output_list += ['Fy']
+        if 'Ez' in output_list and 'By' in output_list:
+            output_list += ['Fz']
 
         return output_list
 

--- a/lampy/lampy/Simulation.py
+++ b/lampy/lampy/Simulation.py
@@ -3,8 +3,17 @@ from .datas.Field import Field
 from .datas.Parts import Particles
 from .datas.Diag import Diagnostics
 import matplotlib.pyplot as plt
-import seaborn as sns
 import os
+
+try:
+    import seaborn as sns
+    imported_seaborn = True
+except:
+    print("Cannot find seaborn module. Plots will be drawn according to the\
+            standard matplotlib style.")
+    imported_seaborn = False
+finally:
+    pass
 
 
 class Simulation(object):
@@ -38,11 +47,19 @@ class Simulation(object):
     s.outputs : list
         List of all the available generated outputs
     s.Field : class
-        Class containing all the method to manipulate fields data.
+        Class containing all the methods to manipulate fields data.
         Check the informations about the Field class
         by typing
 
         >>> help(s.Field)
+
+    s.Particles : class
+        Class containing all the methods to manipulate particle data.
+        Check the informations about the Particles class
+        by typing
+
+        >>> help(s.Particles)
+
     """
 
     def __init__(self, path=os.getcwd()):
@@ -64,8 +81,11 @@ class Simulation(object):
             List of all the available generated outputs
         """
         plt.ion()
-        sns.set()
-        sns.set_style('ticks')
+
+        if imported_seaborn:
+            sns.set()
+            sns.set_style('ticks')
+
         self.params = self._open_folder(path)
         self.dx = self.params['dx']
         if 'dz' in self.params.keys():

--- a/lampy/lampy/Simulation.py
+++ b/lampy/lampy/Simulation.py
@@ -3,6 +3,7 @@ from .datas.Field import Field
 from .datas.Parts import Particles
 from .datas.Diag import Diagnostics
 import matplotlib.pyplot as plt
+import seaborn as sns
 import os
 
 
@@ -63,6 +64,8 @@ class Simulation(object):
             List of all the available generated outputs
         """
         plt.ion()
+        sns.set()
+        sns.set_style('ticks')
         self.params = self._open_folder(path)
         self.dx = self.params['dx']
         if 'dz' in self.params.keys():

--- a/lampy/lampy/__version__.py
+++ b/lampy/lampy/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.5.post4"
+__version__ = "0.2.0"

--- a/lampy/lampy/__version__.py
+++ b/lampy/lampy/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.5"
+__version__ = "0.1.5.post4"

--- a/lampy/lampy/datas/Diag.py
+++ b/lampy/lampy/datas/Diag.py
@@ -37,7 +37,7 @@ class Diagnostics(object):
         timestep : float
             Time at which the diagnostic is read.
 
-        Results
+        Returns
         --------
         totdata : dict
             Function 'read_ionz_diagnostic' returns a dictionary with

--- a/lampy/lampy/datas/Field.py
+++ b/lampy/lampy/datas/Field.py
@@ -9,6 +9,10 @@ _axis_names = ['x', 'y', 'z']
 _Electromagnetic_fields = ['Ex', 'Ey', 'Ez', 'Bx', 'By', 'Bz']
 _Envelope = ['A', 'a']
 _Densities = ['rho_electrons', 'rho_fluid', 'rho_protons']
+_Lorentz_force = ['Fy', 'Fz']
+# Lorentz force is assumed for a relativistic particle travelling along the x
+# direction
+
 for i in range(6):
     _Densities += ['rho_ion'+str(i)]
 
@@ -45,7 +49,13 @@ class Field(object):
     def _field_read(self, field_name, timestep):
 
         file_path = self._Simulation._derive_file_path(field_name, timestep)
-        f, x, y, z = read_ALaDyn_bin(file_path, self._params)
+        try:
+            f, x, y, z = read_ALaDyn_bin(file_path, self._params)
+        except FileNotFoundError:
+            print("""
+        Field {} not available, impossible to read.
+            """.format(field_name))
+            raise
 
         self._stored_fields[(field_name, timestep)] = f
         self._stored_axis[('x', timestep)] = x
@@ -81,12 +91,35 @@ class Field(object):
 
     def _return_field(self, field_name, timestep):
 
+        Lorentz_force = False
         field_list = self._search_field_by_timestep(timestep)
+
+        if field_name in _Lorentz_force:
+            Lorentz_force = True
+            component = field_name[1]
+            if component == 'y':
+                fields = ['Ey', 'Bz']
+            elif component == 'z':
+                fields = ['Ez', 'By']
+
         if field_name in field_list:
             pass
-
-        else:
+        elif not Lorentz_force:
             self._field_read(field_name, timestep)
+        else:
+            stor_fie = list()
+            for field in fields:
+                if field in field_list:
+                    pass
+                else:
+                    self._field_read(field, timestep)
+                stor_fie += [self._stored_fields[(field, timestep)]]
+            if component == 'y':
+                self._stored_fields[(field_name, timestep)] = \
+                    stor_fie[0] - stor_fie[1]
+            elif component == 'z':
+                self._stored_fields[(field_name, timestep)] = \
+                    stor_fie[0] + stor_fie[1]
 
     def _search_field_by_field(self, field_name):
 
@@ -152,8 +185,9 @@ class Field(object):
 
         accepted_types = [str, np.ndarray]
         if type(field) not in accepted_types:
-            print("""Input field must be either a string with the field name
-            or a numpy array """)
+            print("""
+        Input field must be either a string with the field name or a numpy
+        array """)
             return
 
         if 'norm' in kwargs:
@@ -162,11 +196,14 @@ class Field(object):
         else:
             norm = None
 
-        timestep = self._Simulation._nearest_time(timestep)
+        if field not in self._Simulation.outputs:
+            print("""
+        {} is not available.
+        Available output are {}.
+        """.format(field, self._Simulation.outputs))
+            return
 
-        if type(field) is str:
-            file_path = self._Simulation._derive_file_path(field, timestep)
-            file_path = file_path+'.bin'
+        timestep = self._Simulation._nearest_time(timestep)
 
         folder = _translate_timestep(timestep, self._timesteps)
         box_limits = self._box_limits[folder]
@@ -325,11 +362,14 @@ class Field(object):
         else:
             norm = None
 
-        timestep = self._Simulation._nearest_time(timestep)
+        if field not in self._Simulation.outputs:
+            print("""
+        {} is not available.
+        Available output are {}.
+        """.format(field, self._Simulation.outputs))
+            return
 
-        if type(field) is str:
-            file_path = self._Simulation._derive_file_path(field, timestep)
-            file_path = file_path+'.bin'
+        timestep = self._Simulation._nearest_time(timestep)
 
         folder = _translate_timestep(timestep, self._timesteps)
         box_limits = self._box_limits[folder]

--- a/lampy/lampy/datas/Field.py
+++ b/lampy/lampy/datas/Field.py
@@ -113,7 +113,7 @@ class Field(object):
 
         This method produces a 2D map of the given field
         at the given timestep.
-        It is based on pylab.imshow, so it accepts all its **kwargs.
+        It is based on pyplot.pcolormesh, so it accepts all its **kwargs.
 
         Parameters
         --------
@@ -243,8 +243,7 @@ class Field(object):
             if self.comoving or comoving:
                 x = x-x[0]
             y = self._stored_axis[('y', timestep)]
-            plt.imshow(f.transpose(), origin='low',
-                       extent=(x[0], x[-1], y[0], y[-1]), **kwargs)
+            plt.pcolormesh(x, y, f.transpose(), **kwargs)
 
         elif self._params['n_dimensions'] == 3:
 
@@ -254,8 +253,7 @@ class Field(object):
                     x = x-x[0]
                 y = self._stored_axis[('y', timestep)]
                 nz_map = map_plane['z']
-                plt.imshow(f[..., nz_map].transpose(), origin='low',
-                           extent=(x[0], x[-1], y[0], y[-1]), **kwargs)
+                plt.pcolormesh(x, y, f[..., nz_map].transpose(), **kwargs)
 
             elif plane == 'xz' or plane == 'zx':
                 x = self._stored_axis[('x', timestep)]
@@ -263,15 +261,13 @@ class Field(object):
                     x = x-x[0]
                 z = self._stored_axis[('z', timestep)]
                 ny_map = map_plane['y']
-                plt.imshow(f[:, ny_map, :].transpose(), origin='low',
-                           extent=(x[0], x[-1], z[0], z[-1]), **kwargs)
+                plt.pcolormesh(x, z, f[:, ny_map, :].transpose(), **kwargs)
 
             elif plane == 'zy' or plane == 'yz':
                 y = self._stored_axis[('y', timestep)]
                 z = self._stored_axis[('z', timestep)]
                 nx_map = map_plane['x']
-                plt.imshow(f[nx_map, ...].transpose(), origin='low',
-                           extent=(y[0], y[-1], z[0], z[-1]), **kwargs)
+                plt.pcolormesh(y, z, f[nx_map, ...].transpose(), **kwargs)
 
     def lineout(self, field, timestep, axis='x',
                 normalized=False, comoving=False, **kwargs):

--- a/lampy/lampy/datas/Field.py
+++ b/lampy/lampy/datas/Field.py
@@ -506,7 +506,7 @@ class Field(object):
         time : float
             Instant at which array is retrieved
 
-        Results
+        Returns
         --------
         field : dict
             Data are returned as a dictionary.
@@ -532,7 +532,7 @@ class Field(object):
         time : float
             Instant at which array is retrieved
 
-        Results
+        Returns
         --------
         axis : dict
             Data are returned as a dictionary.

--- a/lampy/lampy/datas/Field.py
+++ b/lampy/lampy/datas/Field.py
@@ -258,7 +258,7 @@ class Field(object):
             f = field
 
         if self.normalized or normalized:
-            if field in _Electromagnetic_fields:
+            if field in _Electromagnetic_fields or field in _Lorentz_force:
                 if norm is None:
                     norm = self._E0
 
@@ -419,7 +419,7 @@ class Field(object):
             f = field
 
         if self.normalized or normalized:
-            if field in _Electromagnetic_fields:
+            if field in _Electromagnetic_fields or field in _Lorentz_force:
                 if norm is None:
                     norm = self._E0
 

--- a/lampy/lampy/datas/Parts.py
+++ b/lampy/lampy/datas/Parts.py
@@ -131,14 +131,21 @@ class Particles(object):
             space name is passed, it is optional if the phase space dictionary
             is passed. However, it may be necessary if the longitudinal
             axis is set on 'comoving'.
-        component1 : str
-             First component of the scatter plot. Default is taken as 'x'.
-        component2 : str
-             Second component of the scatter plot. Default is taken as 'y'
-        comoving : bool
+        component1 : str, optional
+            First component of the scatter plot. Default is taken as 'x'.
+        component2 : str, optional
+            Second component of the scatter plot. Default is taken as 'y'
+        comoving : bool, optional
             If True, the longitudinal axis is transformed as xi=x-v_w t.
             Remember that, to obtain the comoving axis, the time is needed
             even when the phase space dictionary is passed.
+        selected_percentage : float, optional
+            A number between 0 and 1. It determines the percentage of particles
+            that have to be selected from the phase space before to be plotted.
+            It can be important for heavily populated phase spaces, that are
+            difficult to load. Once the particles have been selected, they are
+            always kept between various plots, even if the component is
+            changed until the percentage is changed and a new selection happens
 
         Kwargs
         --------
@@ -182,8 +189,9 @@ class Particles(object):
             self._selected_percentage = selected_percentage
             part_number = self._selected_index[(phase_space, time)][0]
             sel_part_numb = int(selected_percentage * part_number)
-            sel_index = np.random.choice(np.arange(part_number),
-                size=sel_part_numb, replace=False)
+            sel_index =\
+                np.random.choice(np.arange(part_number), size=sel_part_numb,
+                                 replace=False)
             sel_index.sort()
             self._selected_index[(phase_space, time)][1] = sel_index
 

--- a/lampy/lampy/datas/Parts.py
+++ b/lampy/lampy/datas/Parts.py
@@ -82,9 +82,23 @@ class Particles(object):
 
         sim = self._Simulation
         ndim = self._params['n_dimensions']
+
+        if phase_space_name not in sim.output:
+            print("""
+        {} is not available.
+        Available output are {}.
+        """.format(phase_space_name, sim.output))
+            return
+
         file_path = sim._derive_file_path(phase_space_name, timestep)
-        phase_space = dict()
-        ps, part_number = total_phase_space_read(file_path, self._params)
+        try:
+            phase_space = dict()
+            ps, part_number = total_phase_space_read(file_path, self._params)
+        except FileNotFoundError:
+            print("""
+        Phase space {} not available, impossible to read.
+            """.format(phase_space_name))
+            raise
 
         if ndim == 3:
             phase_space['x'] = ps[0]
@@ -277,11 +291,6 @@ class Particles(object):
             return
 
         if type(phase_space) is str:
-            file_path = self._Simulation._derive_file_path(phase_space,
-                                                           time)
-            file_path = file_path+'.bin'
-
-        if type(phase_space) is str:
             self._return_phase_space(phase_space, time)
             ps = self._stored_phase_space[(phase_space, time)]
         elif type(phase_space) is dict:
@@ -443,9 +452,6 @@ class Particles(object):
         Please specify a time variable.
                       """)
                 return
-            file_path = self._Simulation._derive_file_path(phase_space,
-                                                           time)
-            file_path = file_path+'.bin'
 
         if type(phase_space) is str:
             self._return_phase_space(phase_space, time)
@@ -732,7 +738,7 @@ class Particles(object):
             First component of the scatter plot. Default is taken as 'x'.
         component2 : str, optional
             Second component of the scatter plot. Default is taken as None
-        
+
         Kwargs
         --------
         List of possible kwargs:
@@ -773,7 +779,7 @@ class Particles(object):
 
         if component2 is None:
             _ = plt.hist(ps[component1], weights=ps['weight'],
-                         bins=bins, density=density)
+                         bins=bins, density=density, alpha=alpha)
 
         else:
             H, xedge, yedge = np.histogram2d(ps[component1], ps[component2],
@@ -782,4 +788,4 @@ class Particles(object):
             H = H.T
             X, Y = np.meshgrid(xedge, yedge)
             H = np.ma.masked_where(H == 0, H)
-            plt.pcolormesh(X, Y, H, cmap=cmap)
+            plt.pcolormesh(X, Y, H, cmap=cmap, alpha=alpha)

--- a/lampy/lampy/fastread/read_phase_space.pyx
+++ b/lampy/lampy/fastread/read_phase_space.pyx
@@ -34,7 +34,7 @@ def total_phase_space_read(file_path, params):
     ps = np.reshape(ps, (jump, part_number), order='F')
     ps = np.asarray(ps)
 
-    return ps
+    return (ps, part_number)
 
 def read_phase_space(ps, n_dimensions, f_path):
 

--- a/lampy/lampy/utilities/Utility.py
+++ b/lampy/lampy/utilities/Utility.py
@@ -32,8 +32,8 @@ for n in range(1, 6):
 
 _translated_filenames['electron_energy'] = 'Elenout'
 _translated_filenames['proton_energy'] = 'Prenout'
-_translated_filenames['phase_space_electron'] = 'Elpout'
-_translated_filenames['phase_space_proton'] = 'Prpout'
+_translated_filenames['phase_space_electrons'] = 'Elpout'
+_translated_filenames['phase_space_protons'] = 'Prpout'
 _translated_filenames['phase_space_ionization'] = 'Eionzout'
 _translated_filenames['phase_space_high_energy'] = 'E_hg_out'
 

--- a/lampy/setup.py
+++ b/lampy/setup.py
@@ -2,7 +2,8 @@ from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from Cython.Build import cythonize
 import numpy
-from lampy.__version__ import __version__
+
+__version__ = "0.1.5.post4"
 
 with open('README.md') as f:
     long_description = f.read()

--- a/lampy/setup.py
+++ b/lampy/setup.py
@@ -3,7 +3,7 @@ from setuptools.extension import Extension
 from Cython.Build import cythonize
 import numpy
 
-__version__ = "0.1.5.post4"
+__version__ = "0.2.0"
 
 with open('README.md') as f:
     long_description = f.read()


### PR DESCRIPTION
# Some issues and enhancements are addressed in these commits.

- The `lpy.Simulation.Particles.scatter` method now has a `select_percentage` flag, to only plot a given percentage of the particles in the phase space
- The `lpy.Simulation.Particles.map_2d` method is now based on `pyplot.pcolormesh`, to correctly plot datas even in case of a stretched grid
- Add the `lpy.Simulation.Particles.histogram` method, that allows the calculation of 1D and 2D weighted histograms for phase space analysis
- Add the relativistic Lorenz force plots
- Plot style is now based on [seaborn](https://seaborn.pydata.org/ "Seaborn") (if available) for a prettier design
- Documentation updated
- Minor bux fixed

**Version V.0.2.0 released**